### PR TITLE
Display proper text on transmission toggle button

### DIFF
--- a/BeaconEmitter/BeaconEmitterView.swift
+++ b/BeaconEmitter/BeaconEmitterView.swift
@@ -42,9 +42,9 @@ struct BeaconEmitterView: View {
             } label: {
                 Spacer()
                 if viewModel.isStarted {
-                    Text("Turn iBeacon on")
-                } else {
                     Text("Turn iBeacon off")
+                } else {
+                    Text("Turn iBeacon on")
                 }
                 Spacer()
             }


### PR DESCRIPTION
If the transmission is running, the button will stop the transmission so it should say "off", and vice versa.